### PR TITLE
Paths other than /auth, underscores in file names

### DIFF
--- a/auth_function/app.py
+++ b/auth_function/app.py
@@ -52,7 +52,7 @@ class AuthPolicy(object):
     """The principal used for the policy, this should be a unique identifier for the end user."""
     version = "2012-10-17"
     """The policy version used for the evaluation. This should always be '2012-10-17'"""
-    pathRegex = "^[/.a-zA-Z0-9-\*]+$"
+    pathRegex = "^[/.a-zA-Z0-9-_\*]+$"
     """The regular expression used to validate resource paths for the policy"""
 
     """these are the internal lists of allowed and denied methods. These are lists

--- a/auth_function/app.py
+++ b/auth_function/app.py
@@ -22,7 +22,7 @@ def lambda_handler(event, context):
     policy.restApiId = apiGatewayArnTmp[0]
     policy.region = tmp[3]
     policy.stage = apiGatewayArnTmp[1]
-    policy.allowMethod('GET', '/auth') 
+    policy.allowMethod('GET', event['path'])
     authResponse = policy.build()
     context = {
         'SomeKey': 'SomeValue'


### PR DESCRIPTION
**Description of changes:**

I ran into two issues:

1. /auth was the only path allowed.  All others were denied access, no matter what value was passed for apiKey.
2. if the path contained an underscore, the lambda would throw an error.  For example:
```
  [ERROR] NameError: Invalid resource path: /js/steve-add_application.js. Path should match ^[/.a-zA-Z0-9-\*]+$
  Traceback (most recent call last):
    File "/var/task/lambda_function.py", line 20, in lambda_handler
      policy.allowMethod('GET', event['path'])
    File "/var/task/lambda_function.py", line 158, in allowMethod
      self._addMethod("Allow", verb, resource, [])
    File "/var/task/lambda_function.py", line 91, in _addMethod
      raise NameError("Invalid resource path: " + resource + ". Path should match " + self.pathRegex)
```

There is one commit per issue.  The changes are small, and they have passed all my tests.

**Notes on the unit tests:**

I wasn't able to run the local tests successfully.  I'm not a Python developer, so I just installed Ubuntu packages until Python stopped returning error messages about missing packages.

*My attempt to run all the tests:*
```
$ export AWS_SAM_STACK_NAME=sam-app; python3 -m unittest discover
  /usr/lib/python3.8/unittest/case.py:630: ResourceWarning: unclosed <ssl.SSLSocket fd=3, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('10.0.0.109', 59954), raddr=('54.240.253.38', 443)>
    self.setUp()
  ResourceWarning: Enable tracemalloc to get the object allocation traceback
  F

  ======================================================================
  FAIL: test_api_gateway (tests.integration.test_api_gateway.TestApiGateway)
  Call the API Gateway endpoint and check the response

  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/home/scorwin/apps/forks/amazon-apigateway-accept-apikeys-as-querystring/tests/integration/test_api_gateway.py", line 55, in test_api_gateway
      self.assertDictEqual(response.json(), {"message": "hello world"})
  AssertionError: {'message': 'Hello from Lambda backend.', 'yourIpAddress': '34.215.143.21'} != {'message': 'hello world'}
  - {'message': 'Hello from Lambda backend.', 'yourIpAddress': '34.215.143.21'}
  + {'message': 'hello world'}
  ----------------------------------------------------------------------
  Ran 1 test in 1.541s
  FAILED (failures=1)

```
The message that causes the failure is what I would expect from the code, so I'm puzzled as to why the test expects something else.


*My attempt to run the unit test directly:*
(since I didn't see it being run with discover)

```
  $ python3 tests/unit/test_handler.py
  Traceback (most recent call last):
    File "tests/unit/test_handler.py", line 5, in <module>
      from hello_world import app
  ModuleNotFoundError: No module named 'hello_world'
```


Is there a different way I should run these tests?

-Steve


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
